### PR TITLE
Updates ResultsTable to show all columns properly

### DIFF
--- a/playground/frontend/src/components/resultstable.js
+++ b/playground/frontend/src/components/resultstable.js
@@ -12,9 +12,7 @@ export default function ResultsTable(results) {
       width: '100%',
       overflowX: 'auto',
       minHeight: '200px',
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
+      textAlign: 'center',
     }}
     >
       {


### PR DESCRIPTION

## Goal

Fix issue where some columns in results are not visible.

## Description

The `<ResultsTable />` has a `display: flex` that makes it not display properly if there's too much content - this fixes that by removing the `display: flex` and instead using the default `block`.

## Before

<img width="1047" alt="Screenshot 2020-02-05 at 16 25 38" src="https://user-images.githubusercontent.com/3296643/73858118-2b4c2380-4838-11ea-9909-a0fc9cd103a6.png">

## After

<img width="1041" alt="Screenshot 2020-02-05 at 16 25 50" src="https://user-images.githubusercontent.com/3296643/73858109-27b89c80-4838-11ea-9c26-8b3743f3cc65.png">
