### PR TITLE
Remove dependency in "playground" that breaks CI

### DIFF
--- a/playground/frontend/src/app.js
+++ b/playground/frontend/src/app.js
@@ -9,10 +9,9 @@ import {
   TextField,
   Grid,
 } from '@material-ui/core';
-import RunIcon from '@material-ui/icons/DoubleArrow';
-
 import ResultsTable from './components/resultstable';
 import Console from './components/console';
+import Icon from './components/icon';
 
 const deSerializeError = obj => Object.assign(new Error(), { stack: undefined }, obj);
 
@@ -127,16 +126,23 @@ class App extends React.Component {
       <div className="App">
         <header className="App-header">
           <h2>North App Playground</h2>
-          <p>status: <span id="connection-state">{connection}</span></p>
+          <p>
+            status:
+            {' '}
+            <span id="connection-state">{connection}</span>
+          </p>
         </header>
         <div className="main-content-container">
           <Grid container spacing={4}>
             <Grid item xs={3}>
               <h3>How to test an integration</h3>
               <p>
-                  1/ Select an integration<br />
-                  2/ Fill out username/password if needed<br />
-                  3/ Open Chrome console to see results (any change in any field will trigger a re-run)<br />
+                  1/ Select an integration
+                <br />
+                  2/ Fill out username/password if needed
+                <br />
+                  3/ Open Chrome console to see results (any change in any field will trigger a re-run)
+                <br />
               </p>
               <FormControl
                 style={{ width: '100%' }}
@@ -149,7 +155,7 @@ class App extends React.Component {
                   onChange={this.handleChange}
                 >
                   {integrations.map(integration => (
-                    <MenuItem key={integration} value={integration}>{integration}</MenuItem> 
+                    <MenuItem key={integration} value={integration}>{integration}</MenuItem>
                   ))}
                 </Select>
                 <TextField
@@ -177,7 +183,8 @@ class App extends React.Component {
                   style={{ marginTop: '16px' }}
                 >
                   Run
-                  <RunIcon />
+                  {' '}
+                  <Icon type="double-arrow" />
                 </Button>
               </FormControl>
             </Grid>

--- a/playground/frontend/src/components/consoleheader.js
+++ b/playground/frontend/src/components/consoleheader.js
@@ -8,9 +8,7 @@ import {
   IconButton,
   Tooltip,
 } from '@material-ui/core';
-import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
-import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
-import ClearIcon from '@material-ui/icons/Clear';
+import Icon from './icon';
 
 
 // As defined here: https://github.com/tmrowco/northapp-contrib/blob/master/playground/server/index.js#L77-L81
@@ -53,9 +51,9 @@ export default function ConsoleHeader({
         }
       >
         {direction === 'descending' ? (
-          <ArrowDownwardIcon />
+          <Icon type="arrow-down" />
         ) : (
-          <ArrowUpwardIcon />
+          <Icon type="arrow-up" />
         )}
       </IconButton>
     </Tooltip>
@@ -70,7 +68,7 @@ export default function ConsoleHeader({
         aria-label={`sort-${oppositeDirection}`}
         onClick={onClearConsole}
       >
-        <ClearIcon />
+        <Icon type="clear" />
       </IconButton>
     </Tooltip>
   );

--- a/playground/frontend/src/components/icon.js
+++ b/playground/frontend/src/components/icon.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import doubleArrow from '../icons/double-arrow.svg';
+import arrowDown from '../icons/arrow-down.svg';
+import arrowUp from '../icons/arrow-up.svg';
+import clear from '../icons/clear.svg';
+
+const ICONS = {
+  'double-arrow': doubleArrow,
+  'arrow-down': arrowDown,
+  'arrow-up': arrowUp,
+  clear,
+};
+
+const Icon = ({ type }) => (
+  <span
+    style={{ height: 24 }}
+    dangerouslySetInnerHTML={{ __html: ICONS[type] }}
+  />
+);
+
+export default Icon;

--- a/playground/frontend/src/icons/arrow-down.svg
+++ b/playground/frontend/src/icons/arrow-down.svg
@@ -1,0 +1,1 @@
+<svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true" role="presentation"><path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"></path></svg>

--- a/playground/frontend/src/icons/arrow-up.svg
+++ b/playground/frontend/src/icons/arrow-up.svg
@@ -1,0 +1,1 @@
+<svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true" role="presentation"><path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"></path></svg>

--- a/playground/frontend/src/icons/clear.svg
+++ b/playground/frontend/src/icons/clear.svg
@@ -1,0 +1,1 @@
+<svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true" role="presentation"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path></svg>

--- a/playground/frontend/src/icons/double-arrow.svg
+++ b/playground/frontend/src/icons/double-arrow.svg
@@ -1,0 +1,1 @@
+<svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true" role="presentation"><path d="M15.5 5H11l5 7-5 7h4.5l5-7z"></path><path d="M8.5 5H4l5 7-5 7h4.5l5-7z"></path></svg>

--- a/playground/package.json
+++ b/playground/package.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "@babel/register": "^7.6.2",
     "@material-ui/core": "^4.4.3",
-    "@material-ui/icons": "^4.4.3",
     "@material-ui/styles": "^4.4.3",
     "console-feed": "^2.8.10",
     "express": "^4.16.4",
@@ -34,6 +33,7 @@
     "css-loader": "^3.2.0",
     "file-loader": "^4.2.0",
     "style-loader": "^1.0.0",
+    "svg-inline-loader": "^0.8.2",
     "webpack-cli": "^3.3.9",
     "webpack-dev-server": "^3.8.1"
   }

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -20,10 +20,10 @@ module.exports = {
               [
                 '@babel/preset-env',
                 {
-                  'modules': 'false', // commonjs,amd,umd,systemjs,auto
-                  'useBuiltIns': 'usage',
-                  'targets': '> 0.25%, not dead',
-                  'corejs': 3,
+                  modules: 'false', // commonjs,amd,umd,systemjs,auto
+                  useBuiltIns: 'usage',
+                  targets: '> 0.25%, not dead',
+                  corejs: 3,
                 },
               ],
             ],
@@ -35,9 +35,13 @@ module.exports = {
         use: ['style-loader', 'css-loader'],
       },
       {
-        test: /\.(png|svg|jpg|gif)$/,
+        test: /\.(png|jpg|gif)$/,
         loader: 'file-loader',
-        options: { name: '/static/[name].[ext]' },
+        options: { name: 'static/[name].[ext]' },
+      },
+      {
+        test: /\.svg$/,
+        loader: 'svg-inline-loader',
       },
     ],
   },

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -727,12 +727,6 @@
     prop-types "^15.7.2"
     react-transition-group "^4.3.0"
 
-"@material-ui/icons@^4.4.3":
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.4.3.tgz#5d4346ddbb2673a1b57ebc78fd6d50bcd88711db"
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-
 "@material-ui/styles@^4.4.3":
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.4.3.tgz#78239177723660093cc9a277db5759c01c693c2a"
@@ -2109,6 +2103,11 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
+emojis-list@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
 emotion-theming@^9.0.0:
   version "9.2.9"
   resolved "https://registry.yarnpkg.com/emotion-theming/-/emotion-theming-9.2.9.tgz#2bfd77fdd47d3f5e60d59d97dd4cea4622657220"
@@ -3338,6 +3337,15 @@ loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.2.3:
   dependencies:
     big.js "^5.2.2"
     emojis-list "^2.0.0"
+    json5 "^1.0.1"
+
+loader-utils@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
+  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
     json5 "^1.0.1"
 
 locate-path@^3.0.0:
@@ -4716,6 +4724,11 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+simple-html-tokenizer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz#05c2eec579ffffe145a030ac26cfea61b980fabe"
+  integrity sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4=
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -5030,6 +5043,15 @@ supports-color@^5.3.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
     has-flag "^3.0.0"
+
+svg-inline-loader@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/svg-inline-loader/-/svg-inline-loader-0.8.2.tgz#9872414f9e4141601e04eb80cda748c9a50dae71"
+  integrity sha512-kbrcEh5n5JkypaSC152eGfGcnT4lkR0eSfvefaUJkLqgGjRQJyKDvvEE/CCv5aTSdfXuc+N98w16iAojhShI3g==
+  dependencies:
+    loader-utils "^1.1.0"
+    object-assign "^4.0.1"
+    simple-html-tokenizer "^0.1.1"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
# Goal
Fix issue where CircleCI fails because of a dependency in `playground`.

## Details

CircleCI is slowed down and fails half the times while trying to download the `@materials-ui/icons` package. 

![Screenshot 2020-02-26 at 10 24 02](https://user-images.githubusercontent.com/3296643/75331142-82b34180-5882-11ea-968f-d0ffda067c84.png)

As we're only using 4 icons from the package, I have copied the icons to assets and loaded them directly instead.