### PR TITLE
Replaces "durationHours" with "endDatetime"

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Activities require a certain formatting:
 {
   id, // a string that uniquely represents this activity
   datetime, // a javascript Date object that represents the start of the activity
-  durationHours, // a floating point that represents the duration of the activity in decimal hours
+  endDatetime, // a javascript Date object that represents the end of the activity. If the activity has no duration, set to "null"
   distanceKilometers, // a floating point that represents the amount of kilometers traveled
   activityType: ACTIVITY_TYPE_TRANSPORTATION,
   transportationMode, // a variable (from definitions.js) that represents the transportation mode
@@ -119,7 +119,7 @@ Activities require a certain formatting:
 {
   id, // a string that uniquely represents this activity
   datetime, // a javascript Date object that represents the start of the activity
-  durationHours, // a floating point that represents the duration of the activity in decimal hours
+  endDatetime, // a javascript Date object that represents the end of the activity. If the activity has no duration, set to "null"
   activityType: ACTIVITY_TYPE_LODGING,
   hotelClass, // a variable (from definitions.js) that represents the class of the hotel
   countryCodeISO2, // a string with the ISO2 country code that represents the country of the hotel
@@ -135,7 +135,7 @@ Activities require a certain formatting:
 {
   id, // a string that uniquely represents this activity
   datetime, // a javascript Date object that represents the start of the activity
-  durationHours, // an integer that represents the duration of the activity
+  endDatetime, // a javascript Date object that represents the end of the activity. If the activity has no duration, set to "null"
   activityType: ACTIVITY_TYPE_ELECTRICITY,
   energyWattHours, // a float that represents the total energy used
   hourlyEnergyWattHours, // (optional) an array of 24 floats that represent the hourly metering values

--- a/co2eq/car/index.js
+++ b/co2eq/car/index.js
@@ -3,6 +3,7 @@ import {
   TRANSPORTATION_MODE_CAR,
 } from '../../definitions';
 import cars from './cars.json';
+import { getActivityDurationHours } from '../utils';
 
 export const modelName = 'car';
 export const modelVersion = '1';
@@ -46,11 +47,12 @@ export function carbonEmissions(activity) {
   let { distanceKilometers } = activity;
   if (!distanceKilometers) {
     // fallback on duration if available
-    if ((activity.durationHours || 0) > 0) {
+    const durationHours = getActivityDurationHours(activity);
+    if ((durationHours || 0) > 0) {
       // https://setis.ec.europa.eu/system/files/Driving_and_parking_patterns_of_European_car_drivers-a_mobility_survey.pdf
-      distanceKilometers = activity.durationHours * 45.0;
+      distanceKilometers = durationHours * 45.0;
     } else {
-      throw new Error(`Couldn't calculate carbonEmissions for activity because distanceKilometers = ${distanceKilometers} and durationHours = ${activity.durationHours}`);
+      throw new Error(`Couldn't calculate carbonEmissions for activity because distanceKilometers = ${distanceKilometers} and datetime = ${activity.datetime} and endDatetime = ${activity.endDatetime}`);
     }
   }
 

--- a/co2eq/flights/index.js
+++ b/co2eq/flights/index.js
@@ -1,5 +1,6 @@
 import { geoDistance } from 'd3-geo'; // todo - add d3-geo in package.json
 import airports from './airports.json';
+import { getActivityDurationHours } from '../utils';
 
 // Key constants used in the model
 // source: https://www.myclimate.org/fileadmin/user_upload/myclimate_-_home/01_Information/01_About_myclimate/09_Calculation_principles/Documents/myclimate-flight-calculator-documentation_EN.pdf
@@ -27,10 +28,10 @@ const bookingClassWeightingFactor = (bookingClass, isShortHaul) => {
 };
 
 // long/short-haul dependent constants
-const passengerToFreightRatio = isShortHaul => (isShortHaul ? 0.93 : 0.74); 
+const passengerToFreightRatio = isShortHaul => (isShortHaul ? 0.93 : 0.74);
 // Passenger aircrafts often transport considerable amounts of freight and mail,
 // in particular in wide-body aircrafts on long-haul flights.
-const averageNumberOfSeats = isShortHaul => (isShortHaul ? 153.51 : 280.21); // 
+const averageNumberOfSeats = isShortHaul => (isShortHaul ? 153.51 : 280.21); //
 const a = isShortHaul => (isShortHaul ? 0 : 0.0001); // empiric fuel consumption parameter
 const b = isShortHaul => (isShortHaul ? 2.714 : 7.104); // empiric fuel consumption parameter
 const c = isShortHaul => (isShortHaul ? 1166.52 : 5044.93); // empiric fuel consumption parameter
@@ -112,10 +113,11 @@ export function activityDistance(activity) {
   }
   // If no airport code is available, and no distance is trusteable
   // therefore, compute distance based on duration
-  if (!activity.durationHours) {
-    throw new Error(`Invalid durationHours ${activity.durationHours}`);
+  const durationHours = getActivityDurationHours(activity);
+  if (!durationHours) {
+    throw new Error(`Invalid durationHours with datetime = ${activity.datetime} and endDatetime = ${activity.endDatetime}`);
   }
-  return distanceFromDuration(activity.durationHours);
+  return distanceFromDuration(durationHours);
 }
 
 /*

--- a/co2eq/hotelpercountry.js
+++ b/co2eq/hotelpercountry.js
@@ -1,5 +1,6 @@
 import countries from './countries.json';
 import { ACTIVITY_TYPE_PURCHASE, PURCHASE_CATEGORY_ENTERTAINMENT_HOTEL } from '../definitions';
+import { getActivityDurationHours } from './utils';
 
 export const modelName = 'hotelpercountry';
 export const modelVersion = '1';
@@ -14,14 +15,14 @@ export const modelCanRunVersion = 1;
 export function modelCanRun(activity) {
   const {
     countryCodeISO2,
-    durationHours,
+    endDatetime,
     activityType,
     purchaseType,
   } = activity;
   if (activityType === ACTIVITY_TYPE_PURCHASE
     && purchaseType === PURCHASE_CATEGORY_ENTERTAINMENT_HOTEL
     && countryCodeISO2
-    && durationHours
+    && endDatetime
   ) {
     if (countries.countries[activity.countryCodeISO2.toUpperCase()]) {
       return true;
@@ -34,7 +35,7 @@ export function modelCanRun(activity) {
 The carbon intensity is per night stayed for one room
 */
 function carbonIntensity(activity) {
-  // The data for all the countries can be found here: 
+  // The data for all the countries can be found here:
   // https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019
   // Source for the division of the "Caribbean region" in ISO2 country codes: (2020, January 9). Carribean. Retrieved from https://en.wikipedia.org/wiki/Caribbean
   let valuePerRoom = 40.3; // This default value is the median of all the values given in the above document
@@ -48,5 +49,6 @@ function carbonIntensity(activity) {
 Carbon emissions of an activity (in kgCO2eq)
 */
 export function carbonEmissions(activity) {
-  return carbonIntensity(activity) * Math.ceil(activity.durationHours / 24);
+  const durationHours = getActivityDurationHours(activity);
+  return carbonIntensity(activity) * Math.ceil(durationHours / 24);
 }

--- a/co2eq/lodging.js
+++ b/co2eq/lodging.js
@@ -4,6 +4,7 @@ import {
   HOTEL_CLASS_FOUR_STARS,
   HOTEL_CLASS_FIVE_STARS,
 } from '../definitions';
+import { getActivityDurationHours } from './utils';
 
 export const modelName = 'lodging';
 export const modelVersion = '1';
@@ -16,8 +17,8 @@ export const explanation = {
 
 export const modelCanRunVersion = 1;
 export function modelCanRun(activity) {
-  const { hotelClass, durationHours } = activity;
-  if (hotelClass && durationHours) {
+  const { hotelClass, endDatetime } = activity;
+  if (hotelClass && endDatetime) {
     return true;
   }
 
@@ -49,5 +50,6 @@ function carbonIntensity(hotelClass) {
 Carbon emissions of an activity (in kgCO2eq)
 */
 export function carbonEmissions(activity) {
-  return carbonIntensity(activity.hotelClass) * Math.ceil(activity.durationHours / 24);
+  const durationHours = getActivityDurationHours(activity);
+  return carbonIntensity(activity.hotelClass) * Math.ceil(durationHours / 24);
 }

--- a/co2eq/utils.js
+++ b/co2eq/utils.js
@@ -1,9 +1,11 @@
+import moment from "moment";
+
 /**
  * Returns the duration in hours between the start and end of an activity
  * @param {Activity} activity Activity
  * @returns {number} Duration in hours between start and end of an activity. Returns null if no endDatetime
  */
-export function getActivityDurationHours(activity) {
+export function getActivityDurationHours(activity, precise = true) {
     if (!activity.endDatetime) return null;
-    return (activity.endDatetime - activity.datetime) / 36e5;
+    return moment(activity.endDatetime).diff(moment(activity.datetime), 'hours', precise);
 }

--- a/co2eq/utils.js
+++ b/co2eq/utils.js
@@ -1,0 +1,9 @@
+/**
+ * Returns the duration in hours between the start and end of an activity
+ * @param {Activity} activity Activity
+ * @returns {number} Duration in hours between start and end of an activity. Returns null if no endDatetime
+ */
+export function getActivityDurationHours(activity) {
+    if (!activity.endDatetime) return null;
+    return (activity.endDatetime - activity.datetime) / 36e5;
+}

--- a/integrations/electricity/orsted.js
+++ b/integrations/electricity/orsted.js
@@ -111,11 +111,11 @@ async function collect(state, logger) {
   ).map(([k, values]) => ({
     id: `orsted${k}`,
     datetime: moment(k).toDate(),
+    endDatetime: moment(k).add(values.length, 'hour').toDate(),
     activityType: ACTIVITY_TYPE_ELECTRICITY,
     energyWattHours: values
       .map(x => x.kWh * 1000.0) // kWh -> Wh
       .reduce((a, b) => a + b, 0),
-    durationHours: values.length,
     hourlyEnergyWattHours: values.map(x => x.kWh * 1000.0),
     locationLon,
     locationLat,

--- a/integrations/electricity/renault-zoe.js
+++ b/integrations/electricity/renault-zoe.js
@@ -50,7 +50,7 @@ async function _login(username, password) {
     const text = await res.text();
     throw new HTTPError(text, res.status);
   }
-  
+
   if (res.body.user.associated_vehicles.length > 1) {
     throw Error('More than one VIN number detected.');
   }
@@ -143,7 +143,6 @@ async function collect(state = {}, logger, utils) {
     if (d.type === 'END_NOTIFICATION' && prev.type === 'START_NOTIFICATION') {
       const start = moment(prev.date);
       const end = moment(d.date);
-      const duration = end.valueOf() - start.valueOf(); // in ms
       const energyDeltaWattHours = (d.charge_level - prev.charge_level) / 100.0 * BATTERY_SIZE;
       if (energyDeltaWattHours <= 0) {
         logger.logWarning(`Invalid energy delta measurement of ${energyDeltaWattHours}Wh obtained`);
@@ -152,7 +151,7 @@ async function collect(state = {}, logger, utils) {
           id: `renaultzoe${start.toISOString()}`,
           activityType: ACTIVITY_TYPE_ELECTRIC_VEHICLE_CHARGING,
           datetime: start.toDate(),
-          durationHours: duration / 1000.0 / 3600.0,
+          endDatetime : end.toDate() - start.toDate() <= 0 ? null : end.toDate(),
           energyWattHours: energyDeltaWattHours,
           locationLon,
           locationLat,

--- a/integrations/electricity/sense.js
+++ b/integrations/electricity/sense.js
@@ -13,7 +13,7 @@ async function request(method, call, token, params) {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   };
   if (token) {
-    req.headers['Authorization'] = `Bearer ${token}`;
+    req.headers.Authorization = `Bearer ${token}`;
   }
 
   const url = `https://api.sense.com/apiservice/api/v1/${call}?${new URLSearchParams(params).toString()}`;
@@ -81,9 +81,9 @@ async function collect(state, { logWarning }, { settings }) {
     activities: [{
       id: `sense-${monitor}-${start.toISOString()}`,
       datetime: start.toDate(),
+      endDatetime: whs.length ? start.add(whs.length, 'hour').toDate() : null,
       activityType: ACTIVITY_TYPE_ELECTRICITY,
       energyWattHours: whs.reduce((a, b) => a + b, 0),
-      durationHours: whs.length,
       hourlyEnergyWattHours: whs,
       locationLon,
       locationLat,

--- a/integrations/electricity/tesla-cockpit.js
+++ b/integrations/electricity/tesla-cockpit.js
@@ -125,7 +125,7 @@ async function collect(state, logger, utils) {
       id: `teslacockpit${d.ChargeID}`,
       activityType: ACTIVITY_TYPE_ELECTRIC_VEHICLE_CHARGING,
       datetime: startMoment.toDate(),
-      durationHours: endMoment.diff(startMoment, 'minutes') / 60.0,
+      endDatetime: endMoment.toDate(),
       energyWattHours,
       locationLat,
       locationLon,

--- a/integrations/transportation/automatic.js
+++ b/integrations/transportation/automatic.js
@@ -40,23 +40,27 @@ async function fetchTripsFromURL(tripURL, logger) {
     throw new HTTPError(text, res.status);
   }
 
-  const data = await res.json(); 
+  const data = await res.json();
   return data;
 }
 
-const toActivities = tripArray => (tripArray || []).map(k => ({
-  id: k.id,
-  activityType: ACTIVITY_TYPE_TRANSPORTATION,
-  datetime: new Date(k.started_at),
-  vehicle: k.vehicle,
-  durationHours: (Math.round(k.duration_s) / 3600).toFixed(2),
-  distanceKilometers: k.distance_m / 1000,
-  transportationMode: TRANSPORTATION_MODE_CAR,
-  startLat: k.start_location.lat,
-  startLon: k.start_location.lon,
-  endLat: k.end_location.lat,
-  endLon: k.end_location.lon,
-}));
+const toActivities = tripArray => (tripArray || []).map(k => {
+    const datetime = new Date(k.started_at);
+    return {
+      id: k.id,
+      activityType: ACTIVITY_TYPE_TRANSPORTATION,
+      datetime,
+      vehicle: k.vehicle,
+      endDatetime: new Date(datetime.getTime() + k.duration_s * 1000),
+      distanceKilometers: k.distance_m / 1000,
+      transportationMode: TRANSPORTATION_MODE_CAR,
+      startLat: k.start_location.lat,
+      startLon: k.start_location.lon,
+      endLat: k.end_location.lat,
+      endLon: k.end_location.lon,
+    }
+  }
+);
 
 async function fetchOffsetActivities(start, end, logger) {
   const startDateString = start === null ? '' : `started_at_gte=${toUnixSeconds(start)}&`;

--- a/integrations/transportation/minvolkswagen.js
+++ b/integrations/transportation/minvolkswagen.js
@@ -136,7 +136,7 @@ async function collect(state, logger) {
   const token = await loginWithDeviceToken(deviceToken, logger);
   const cars = await getCarIds(token, userId, logger);
 
-  
+
   let trips = [];
   // eslint-disable-next-line no-restricted-syntax
   for (const vehicleId of cars) {
@@ -144,15 +144,18 @@ async function collect(state, logger) {
     trips = trips.concat(await getTrips(token, vehicleId, lastUpdate, logger));
   }
 
-  const activities = trips.map(trip => ({
-    id: `minvolkswagen_${trip.id}`,
-    activityType: ACTIVITY_TYPE_TRANSPORTATION,
-    datetime: new Date(trip.time),
-    durationHours: trip.duration / 60,
-    distanceKilometers: trip.mileage,
-    transportationMode: TRANSPORTATION_MODE_CAR,
-    pathLonLats: trip.positions.map(p => ([p.longitude, p.latitude])),
-  }));
+  const activities = trips.map(trip => {
+    const datetime = new Date(trip.time);
+    return {
+      id: `minvolkswagen_${trip.id}`,
+      activityType: ACTIVITY_TYPE_TRANSPORTATION,
+      datetime,
+      endDatetime: new Date(datetime.getTime() + 60000 * trip.duration),
+      distanceKilometers: trip.mileage,
+      transportationMode: TRANSPORTATION_MODE_CAR,
+      pathLonLats: trip.positions.map(p => ([p.longitude, p.latitude])),
+    }
+  });
 
   return { state: { ...state, lastUpdate: new Date().toISOString() }, activities };
 }

--- a/integrations/transportation/rejsekort.js
+++ b/integrations/transportation/rejsekort.js
@@ -171,13 +171,13 @@ function parseTravels(allTravelsHTML, logger) {
               skipRow = false;
               travelIndex += 1;
               travelList[travelIndex] = {};
-              travelList[travelIndex]['number'] = element.textContent;
+              travelList[travelIndex].number = element.textContent;
             }
           }
         }
         if (!skipRow) {
           if (e === 2) {
-            travelList[travelIndex]['date'] = element.textContent;
+            travelList[travelIndex].date = element.textContent;
           }
           if (e === 3) {
             travelList[travelIndex]['start-time'] = element.textContent;
@@ -199,8 +199,8 @@ function parseTravels(allTravelsHTML, logger) {
   // Change data format for Greenbit
   const activities = [];
   for (let a = 0; a < travelList.length; a += 1) {
-    const splitToken = travelList[a]['date'].indexOf('-') !== -1 ? '-' : '/';
-    const dateSplit = travelList[a]['date'].split(splitToken);
+    const splitToken = travelList[a].date.indexOf('-') !== -1 ? '-' : '/';
+    const dateSplit = travelList[a].date.split(splitToken);
     const startTime = new Date(`20${dateSplit[2]}-${dateSplit[1]}-${dateSplit[0]}T${travelList[a]['start-time']}`);
     const endStr = `20${dateSplit[2]}-${dateSplit[1]}-${dateSplit[0]}T${travelList[a]['end-time']}`;
     let endTime = new Date(endStr);
@@ -216,11 +216,11 @@ function parseTravels(allTravelsHTML, logger) {
     }
 
     activities.push({
-      id: `rejsekort${travelList[a]['number']}`,
+      id: `rejsekort${travelList[a].number}`,
       datetime: endTime,
-      activityType: ACTIVITY_TYPE_TRANSPORTATION,
       // this currently only works for travels within the same date
-      durationHours: (endTime.getTime() - startTime.getTime()) / 3600000,
+      endDatetime: new Date(endTime.getTime() + (endTime.getTime() - startTime().getTime())),
+      activityType: ACTIVITY_TYPE_TRANSPORTATION,
       transportationMode: TRANSPORTATION_MODE_PUBLIC_TRANSPORT,
       departureStation: travelList[a]['start-station'].replace('Line : ', ''),
       destinationStation: travelList[a]['end-station'].replace('Line : ', ''),

--- a/integrations/transportation/ryanair.js
+++ b/integrations/transportation/ryanair.js
@@ -117,7 +117,7 @@ async function getActivities(pastBookings, customerId, token) {
     .map(k => ({
       id: `ryanairB${k.bookingId}${k.flightInfo.FlightNumber}`,
       datetime: k.flightInfo.DepartLocal,
-      endDatetime: k.flightInfo.ArriveLocal, // TODO(df): UNTESTED! Does it exist?
+      endDatetime: moment(k.flightInfo.DepartLocal).add(moment(k.flightInfo.Arrive).diff(moment(k.flightInfo.Depart))).toDate(),
       activityType: ACTIVITY_TYPE_TRANSPORTATION,
       transportationMode: TRANSPORTATION_MODE_PLANE,
       carrier: 'Ryanair',

--- a/integrations/transportation/ryanair.js
+++ b/integrations/transportation/ryanair.js
@@ -117,7 +117,7 @@ async function getActivities(pastBookings, customerId, token) {
     .map(k => ({
       id: `ryanairB${k.bookingId}${k.flightInfo.FlightNumber}`,
       datetime: k.flightInfo.DepartLocal,
-      durationHours: moment(k.flightInfo.Arrive).diff(moment(k.flightInfo.Depart), 'minutes') / 60,
+      endDatetime: k.flightInfo.ArriveLocal, // TODO(df): UNTESTED! Does it exist?
       activityType: ACTIVITY_TYPE_TRANSPORTATION,
       transportationMode: TRANSPORTATION_MODE_PLANE,
       carrier: 'Ryanair',

--- a/integrations/transportation/tfl.js
+++ b/integrations/transportation/tfl.js
@@ -22,7 +22,7 @@ function generateOysterActivities(travelDays) {
         activities.push({
           id: journey.StartTime, // a string that uniquely represents this activity
           datetime: journey.StartTime, // a javascript Date object that represents the start of the activity
-          durationHours: journey.EndTime && moment(journey.EndTime).diff(moment(journey.StartTime)) / (60 * 60 * 1000), // a floating point that represents the duration of the activity in decimal hours
+          endDatetime: journey.EndTime,
           distanceKilometers: null, // a floating point that represents the amount of kilometers traveled (https://www.whatdotheyknow.com/request/bus_passenger_journey_times)
           activityType: ACTIVITY_TYPE_TRANSPORTATION,
           transportationMode: TRANSPORTATION_MODE_PUBLIC_TRANSPORT, // a variable (from definitions.js) that represents the transportation mode
@@ -80,7 +80,7 @@ function generateContactlessActivities(travelDays) {
       activities.push({
         id: journey.StartTime, // a string that uniquely represents this activity
         datetime: journey.StartTime, // a javascript Date object that represents the start of the activity
-        durationHours: journey.EndTime && moment(journey.EndTime).diff(moment(journey.StartTime)) / (60 * 60 * 1000), // a floating point that represents the duration of the activity in decimal hours
+        endDatetime: journey.EndTime,
         distanceKilometers: null, // a floating point that represents the amount of kilometers traveled (https://www.whatdotheyknow.com/request/bus_passenger_journey_times)
         activityType: ACTIVITY_TYPE_TRANSPORTATION,
         transportationMode: TRANSPORTATION_MODE_PUBLIC_TRANSPORT, // a variable (from definitions.js) that represents the transportation mode

--- a/integrations/transportation/trainline.js
+++ b/integrations/transportation/trainline.js
@@ -95,7 +95,7 @@ async function collect(state, logger) {
       activities.push({
         id: `${tripId}-${get(trip, 'booking.outward.origin.id')}`, // a string that uniquely represents this activity
         datetime: outwardDate, // a javascript Date object that represents the start of the activity
-        durationHours: calculateDurationFromLegs(get(trip, 'booking.outward.legs'), []), // a floating point that represents the duration of the activity in decimal hours
+        endDatetime: new Date(calculateDurationFromLegs(get(trip, 'booking.outward.legs'), []) * 36e5),
         activityType: ACTIVITY_TYPE_TRANSPORTATION,
         transportationMode: matchTransportMode(get(trip, 'booking.outward.legs[0].transportMode'), logger), // a variable (from definitions.js) that represents the transportation mode
         departureStation: get(trip, 'booking.outward.origin.name'), // (for other travel types) a string that represents the original starting point
@@ -116,7 +116,7 @@ async function collect(state, logger) {
       activities.push({
         id: `${tripId}-${get(trip, 'booking.inward.origin.id')}`, // a string that uniquely represents this activity
         datetime: inwardDate, // a javascript Date object that represents the start of the activity
-        durationHours: inwardDuration, // a floating point that represents the duration of the activity in decimal hours
+        endDatetime: new Date(inwardDate.getTime() + inwardDuration * 36e5),
         activityType: ACTIVITY_TYPE_TRANSPORTATION,
         transportationMode: matchTransportMode(inwardTransportationMode, logger), // a variable (from definitions.js) that represents the transportation mode
         departureStation: get(trip, 'booking.inward.origin.name'), // (for other travel types) a string that represents the original starting point

--- a/integrations/transportation/uber.js
+++ b/integrations/transportation/uber.js
@@ -45,8 +45,8 @@ async function queryActivitiesFromOffset(offset, logger) {
     activityType: ACTIVITY_TYPE_TRANSPORTATION,
     carrier: 'Uber',
     datetime: new Date(d.start_time * 1000.0),
+    endDatetime: new Date(d.end_time * 1000.0),
     distanceKilometers: d.distance * MILES_TO_KM, // the origin in given in miles
-    durationHours: (new Date(d.end_time * 1000.0) - new Date(d.start_time * 1000.0)) / 1000.0 / 3600.0,
     transportationMode: TRANSPORTATION_MODE_CAR,
     locationLon: d.start_city.longitude,
     locationLat: d.start_city.latitude,

--- a/integrations/transportation/wizzair.js
+++ b/integrations/transportation/wizzair.js
@@ -62,7 +62,7 @@ async function getPastBookings() {
     throw new HTTPError(text, pastBookings.status);
   }
 
-  return { 
+  return {
     pastBookings: pastBookings.body.pastBookings,
   };
 }
@@ -114,7 +114,7 @@ async function getActivities(allUniqueFlights) {
     .map(k => ({
       id: k.id,
       datetime: k.flight.departureDate,
-      durationHours: moment.duration(k.flight.duration).asHours(),
+      endDatetime: moment(k.flight.departureDate).add(k.flight.duration).toDate(),
       activityType: ACTIVITY_TYPE_TRANSPORTATION,
       transportationMode: TRANSPORTATION_MODE_PLANE,
       carrier: 'Wizzair',
@@ -163,7 +163,7 @@ async function collect(state) {
   const activities = await getActivities(flights);
   fetchIndex += HISTORY_API_FETCH_LIMIT;
 
-  return { 
+  return {
     activities,
     state: {
       ...state,


### PR DESCRIPTION
Part of https://github.com/tmrowco/tmrow/issues/1932. This should replace all usages of `durationHours` with `endDatetime`. 

I disabled the `prettier` `formatOnSave` hook, as otherwise there would be too many unnecessary changes. But somehow the 2 files refactored in the commit 931fd9f are always automatically formatted...

Not sure how we should proceed with regards to testing?