### PR TITLE
Adds "lineItems" to replace "ingredients" and purchase type fields

### DIFF
--- a/co2eq/hotelpercountry.js
+++ b/co2eq/hotelpercountry.js
@@ -17,10 +17,10 @@ export function modelCanRun(activity) {
     countryCodeISO2,
     endDatetime,
     activityType,
-    purchaseType,
+    lineItems,
   } = activity;
   if (activityType === ACTIVITY_TYPE_PURCHASE
-    && purchaseType === PURCHASE_CATEGORY_ENTERTAINMENT_HOTEL
+    && lineItems && lineItems.length && lineItems.some(l => l.identifier === PURCHASE_CATEGORY_ENTERTAINMENT_HOTEL)
     && countryCodeISO2
     && endDatetime
   ) {

--- a/co2eq/meal.js
+++ b/co2eq/meal.js
@@ -112,7 +112,7 @@ Carbon emissions of an activity (in kgCO2eq)
 */
 export function carbonEmissions(activity) {
   const { mealType, lineItems } = activity;
-  const mealIngredients = lineItems.filter(l => l.unit === UNIT_KILOGRAMS);
+  const mealIngredients = lineItems && lineItems.filter(l => l.unit === UNIT_KILOGRAMS);
 
   if (mealIngredients && Object.keys(mealIngredients).length > 0) {
     return mealIngredients

--- a/co2eq/meal.js
+++ b/co2eq/meal.js
@@ -116,7 +116,7 @@ export function carbonEmissions(activity) {
 
   if (mealIngredients && Object.keys(mealIngredients).length > 0) {
     return mealIngredients
-      .map(k => carbonIntensityOfIngredient(k.name) * k.value)
+      .map(k => carbonIntensityOfIngredient(k.identifier) * k.value)
       .reduce((a, b) => a + b, 0);
   }
 

--- a/co2eq/meal.js
+++ b/co2eq/meal.js
@@ -7,6 +7,7 @@ import {
   MEAL_TYPE_MEAT_HIGH,
   MEAL_TYPE_MEAT_OR_FISH,
   PURCHASE_CATEGORY_FOOD,
+  UNIT_KILOGRAMS,
 } from '../definitions';
 import {
   getEntryByKey,
@@ -31,8 +32,8 @@ export const explanation = {
 
 export const modelCanRunVersion = 1;
 export function modelCanRun(activity) {
-  const { mealType, ingredients } = activity;
-  if (mealType || (ingredients && Object.keys(ingredients).length > 0)) {
+  const { mealType, lineItems } = activity;
+  if (mealType || (lineItems && lineItems.length && lineItems.filter(l => l.unit === UNIT_KILOGRAMS).length)) {
     return true;
   }
 
@@ -43,7 +44,7 @@ const foodBranch = getEntryByPath([PURCHASE_CATEGORY_FOOD]);
 const ingredients = getDescendants(foodBranch);
 export const INGREDIENT_KEYS = Object.keys(ingredients);
 export const INGREDIENT_CATEGORIES = [
-  ...new Set(Object.keys(foodBranch['_children'])),
+  ...new Set(Object.keys(foodBranch._children)),
 ];
 export const ingredientCategory = {};
 export const ingredientIcon = {};
@@ -110,12 +111,12 @@ function carbonIntensityOfMealType(mealType) {
 Carbon emissions of an activity (in kgCO2eq)
 */
 export function carbonEmissions(activity) {
-  const { mealType } = activity;
-  const mealIngredients = activity.ingredients;
+  const { mealType, lineItems } = activity;
+  const mealIngredients = lineItems.filter(l => l.unit === UNIT_KILOGRAMS);
 
   if (mealIngredients && Object.keys(mealIngredients).length > 0) {
     return mealIngredients
-      .map(k => carbonIntensityOfIngredient(k.name) * k.kilograms)
+      .map(k => carbonIntensityOfIngredient(k.name) * k.value)
       .reduce((a, b) => a + b, 0);
   }
 

--- a/co2eq/meal.js
+++ b/co2eq/meal.js
@@ -33,7 +33,9 @@ export const explanation = {
 export const modelCanRunVersion = 1;
 export function modelCanRun(activity) {
   const { mealType, lineItems } = activity;
-  if (mealType || (lineItems && lineItems.length && lineItems.filter(l => l.unit === UNIT_KILOGRAMS).length)) {
+  // Run if: a) Meal type OR b) ALL line items are of type "ingredient" (which should have kilograms as unit)
+  const ingredients = lineItems && lineItems.length && lineItems.filter(l => l.unit === UNIT_KILOGRAMS);
+  if (mealType || (ingredients && ingredients.length && ingredients.length === lineItems.length)) {
     return true;
   }
 

--- a/co2eq/meal.js
+++ b/co2eq/meal.js
@@ -33,9 +33,7 @@ export const explanation = {
 export const modelCanRunVersion = 1;
 export function modelCanRun(activity) {
   const { mealType, lineItems } = activity;
-  // Run if: a) Meal type OR b) ALL line items are of type "ingredient" (which should have kilograms as unit)
-  const ingredients = lineItems && lineItems.length && lineItems.filter(l => l.unit === UNIT_KILOGRAMS);
-  if (mealType || (ingredients && ingredients.length && ingredients.length === lineItems.length)) {
+  if (mealType || (lineItems && lineItems.length)) {
     return true;
   }
 
@@ -114,10 +112,9 @@ Carbon emissions of an activity (in kgCO2eq)
 */
 export function carbonEmissions(activity) {
   const { mealType, lineItems } = activity;
-  const mealIngredients = lineItems && lineItems.filter(l => l.unit === UNIT_KILOGRAMS);
 
-  if (mealIngredients && Object.keys(mealIngredients).length > 0) {
-    return mealIngredients
+  if (lineItems && Object.keys(lineItems).length > 0) {
+    return lineItems
       .map(k => carbonIntensityOfIngredient(k.identifier) * k.value)
       .reduce((a, b) => a + b, 0);
   }

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -143,10 +143,10 @@ function extractComptabileUnitAndAmount(lineItem, entry) {
  */
 export function carbonEmissionOfLineItem(lineItem) {
   // The generic identifier property holds the purchaseType value, so rename to make clear..
-  const { identifier: purchaseType } = lineItem;
+  const { identifier } = lineItem;
   const entry = getEntryByKey(purchaseType);
   if (!entry) {
-    throw new Error(`Unknown purchaseType: ${purchaseType}`);
+    throw new Error(`Unknown purchaseType identifier: ${identifier}`);
   }
   if (!entry.intensityKilograms) {
     throw new Error(`Missing carbon intensity for purchaseType: ${purchaseType}`);

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -111,9 +111,9 @@ export function modelCanRun(activity) {
 function correctWithParticipants(footprint, participants) {
   return footprint / (participants || 1);
 }
-function extractEur(activity) {
-  return (activity.costAmount && activity.costCurrency)
-    ? convertToEuro(activity.costAmount, activity.costCurrency)
+function extractEur({ costAmount, costCurrency }) {
+  return (costAmount && costCurrency)
+    ? convertToEuro(costAmount, costCurrency)
     : null;
 }
 
@@ -124,7 +124,7 @@ function extractEur(activity) {
  */
 function extractComptabileUnitAndAmount(lineItem, entry) {
   const isMonetaryItem = getAvailableCurrencies().includes(lineItem.unit);
-  // TODO(df): Hacky, but pretend to pass an activity if monetary...
+  // Extract eurAmount if applicable
   const eurAmount = extractEur({ costCurrency: isMonetaryItem ? lineItem.unit : null, costAmount: isMonetaryItem ? lineItem.value : null });
   // TODO(olc): Also look at potential available conversions
   const availableEntryUnit = entry.unit;
@@ -144,7 +144,7 @@ function extractComptabileUnitAndAmount(lineItem, entry) {
  * Calculates the carbon emissions of a line item entry
  * @param {*} lineItem - Object of the the type { identifier: <string>, unit: <string>, value: <string>, costAmount: <float>, costCurrency: <string> }
  */
-function carbonEmissionOfLineItem(lineItem) {
+export function carbonEmissionOfLineItem(lineItem) {
   // The generic name property holds the purchaseType value, so rename to make clear..
   const { identifier: purchaseType } = lineItem;
   const entry = getEntryByKey(purchaseType);
@@ -155,7 +155,6 @@ function carbonEmissionOfLineItem(lineItem) {
     throw new Error(`Missing carbon intensity for purchaseType: ${purchaseType}`);
   }
 
-  // TODO(df): Hacky! Simulate an activity...
   const { unit, amount } = extractComptabileUnitAndAmount(lineItem, entry);
   if (unit == null || amount == null || !Number.isFinite(amount)) {
     throw new Error(`Invalid unit ${unit} or amount ${amount} for purchaseType ${purchaseType}. Expected ${entry.unit}`);

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -142,11 +142,11 @@ function extractComptabileUnitAndAmount(lineItem, entry) {
 
 /**
  * Calculates the carbon emissions of a line item entry
- * @param {*} lineItem - Object of the the type { name: <string>, unit: <string>, value: <string>, costAmount: <float>, costCurrency: <string> }
+ * @param {*} lineItem - Object of the the type { identifier: <string>, unit: <string>, value: <string>, costAmount: <float>, costCurrency: <string> }
  */
 function carbonEmissionOfLineItem(lineItem) {
   // The generic name property holds the purchaseType value, so rename to make clear..
-  const { name: purchaseType } = lineItem;
+  const { identifier: purchaseType } = lineItem;
   const entry = getEntryByKey(purchaseType);
   if (!entry) {
     throw new Error(`Unknown purchaseType: ${purchaseType}`);
@@ -201,17 +201,14 @@ export function carbonEmissions(activity) {
       break;
 
     case ACTIVITY_TYPE_PURCHASE: {
-      const { costAmount, costCurrency, purchaseType, lineItems } = activity;
+      const { lineItems } = activity;
 
       // First check if lineItems contains and calculate total of all line items
       if (lineItems && lineItems.length) {
         // TODO(df): What to do on a single line error? Abort all? Skip item?
         footprint = lineItems.map(l => carbonEmissionOfLineItem(l)).reduce((a, b) => a + b, 0);
-      } else {
-        // Else take the purchaseType and other fields to calculate by passing a single line item
-        footprint = carbonEmissionOfLineItem({ name: purchaseType, unit: costCurrency || UNIT_ITEM, value: costAmount || 1 });
       }
-      if (!footprint) throw new Error(`Could not calculate carbonIntensity of purchase activity with purchaseType: ${purchaseType} and lineItems: ${JSON.stringify(lineItems)}`)
+      if (!footprint) throw new Error(`Could not calculate carbonIntensity of purchase activity with lineItems: ${JSON.stringify(lineItems)}`)
       break;
     }
 

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -11,7 +11,7 @@ import {
   UNIT_ITEM,
   UNIT_LITER,
 } from '../../definitions';
-import { convertToEuro } from '../../integrations/utils/currency/currency';
+import { convertToEuro, getAvailableCurrencies } from '../../integrations/utils/currency/currency';
 import footprints from './footprints.yml';
 
 export const explanation = {
@@ -26,7 +26,7 @@ export const purchaseIcon = {};
 
 // Traverse and index tree
 function indexNodeChildren(branch, i = 1) {
-  Object.entries(branch['_children'] || []).forEach(([k, v]) => {
+  Object.entries(branch._children || []).forEach(([k, v]) => {
     if (ENTRY_BY_KEY[k]) {
       throw new Error(`Error while indexing footprint tree: There's already an entry for ${k}`);
     }
@@ -51,7 +51,7 @@ export function getEntryByKey(key) {
 export function getEntryByPath(path) {
   let entry = footprints; // root node
   for (let i = 0; i < path.length; i += 1) {
-    entry = (entry['_children'] || {})[path[i]];
+    entry = (entry._children || {})[path[i]];
   }
   return entry;
 }
@@ -67,7 +67,7 @@ export function getDescendants(entry, filter = (_ => true), includeRoot = false)
   let descendants = includeRoot
     ? { [entry.key]: entry }
     : {};
-  Object.values(entry['_children'] || []).filter(filter).forEach((child) => {
+  Object.values(entry._children || []).filter(filter).forEach((child) => {
     descendants = {
       ...descendants,
       ...getDescendants(child, filter, true),
@@ -83,7 +83,7 @@ export const modelVersion = `3_${getChecksumOfFootprints()}`; // This model reli
 export const modelCanRunVersion = 1;
 export function modelCanRun(activity) {
   const {
-    costAmount, costCurrency, activityType, transportationMode, purchaseType,
+    costAmount, costCurrency, activityType, transportationMode, purchaseType, lineItems,
   } = activity;
   if (costAmount && costCurrency) {
     if (activityType === ACTIVITY_TYPE_MEAL) return true;
@@ -102,6 +102,9 @@ export function modelCanRun(activity) {
   if (activityType === ACTIVITY_TYPE_PURCHASE && purchaseType) {
     return true;
   }
+  if (activityType === ACTIVITY_TYPE_PURCHASE && lineItems && lineItems.length) {
+    return true;
+  }
 
   return false;
 }
@@ -113,12 +116,20 @@ function extractEur(activity) {
     ? convertToEuro(activity.costAmount, activity.costCurrency)
     : null;
 }
-function extractComptabileUnitAndAmount(activity, entry) {
-  const eurAmount = extractEur(activity);
+
+/**
+ * Returns the compatible unit and amounts of a line item
+ * @param {*} lineItem - Object of the the type { name: <string>, unit: <string>, value: <string>, costAmount: <float>, costCurrency: <string> }
+ * @param {*} entry - A purchase entry
+ */
+function extractComptabileUnitAndAmount(lineItem, entry) {
+  const isMonetaryItem = getAvailableCurrencies().includes(lineItem.unit);
+  // TODO(df): Hacky, but pretend to pass an activity if monetary...
+  const eurAmount = extractEur({ costCurrency: isMonetaryItem ? lineItem.unit : null, costAmount: isMonetaryItem ? lineItem.value : null });
   // TODO(olc): Also look at potential available conversions
   const availableEntryUnit = entry.unit;
-  if (availableEntryUnit === UNIT_LITER && activity.volumeLiters != null) {
-    return { unit: UNIT_LITER, amount: activity.volumeLiters };
+  if (availableEntryUnit === UNIT_LITER && lineItem.unit === UNIT_LITER) {
+    return { unit: UNIT_LITER, amount: lineItem.value };
   }
   if (availableEntryUnit === UNIT_MONETARY_EUR && eurAmount != null) {
     return { unit: UNIT_MONETARY_EUR, amount: eurAmount };
@@ -126,7 +137,34 @@ function extractComptabileUnitAndAmount(activity, entry) {
   if (availableEntryUnit === UNIT_ITEM) {
     return { unit: UNIT_ITEM, amount: 1 };
   }
-  throw new Error(`Activity has no compatible purchase unit.`);
+  throw new Error(`Line item of activity has no compatible purchase unit.`);
+}
+
+/**
+ * Calculates the carbon emissions of a line item entry
+ * @param {*} lineItem - Object of the the type { name: <string>, unit: <string>, value: <string>, costAmount: <float>, costCurrency: <string> }
+ */
+function carbonEmissionOfLineItem(lineItem) {
+  // The generic name property holds the purchaseType value, so rename to make clear..
+  const { name: purchaseType } = lineItem;
+  const entry = getEntryByKey(purchaseType);
+  if (!entry) {
+    throw new Error(`Unknown purchaseType: ${purchaseType}`);
+  }
+  if (!entry.intensityKilograms) {
+    throw new Error(`Missing carbon intensity for purchaseType: ${purchaseType}`);
+  }
+
+  // TODO(df): Hacky! Simulate an activity...
+  const { unit, amount } = extractComptabileUnitAndAmount(lineItem, entry);
+  if (unit == null || amount == null || !Number.isFinite(amount)) {
+    throw new Error(`Invalid unit ${unit} or amount ${amount} for purchaseType ${purchaseType}. Expected ${entry.unit}`);
+  }
+
+  if (entry.unit !== unit) {
+    throw new Error(`Invalid unit ${unit} given for purchaseType ${purchaseType}. Expected ${entry.unit}`);
+  }
+  return entry.intensityKilograms * amount;
 }
 
 /*
@@ -163,24 +201,17 @@ export function carbonEmissions(activity) {
       break;
 
     case ACTIVITY_TYPE_PURCHASE: {
-      const { purchaseType } = activity;
-      const entry = getEntryByKey(purchaseType);
-      if (!entry) {
-        throw new Error(`Unknown purchaseType: ${purchaseType}`);
-      }
-      if (!entry.intensityKilograms) {
-        throw new Error(`Missing carbon intensity for purchaseType: ${purchaseType}`);
-      }
+      const { costAmount, costCurrency, purchaseType, lineItems } = activity;
 
-      const { unit, amount } = extractComptabileUnitAndAmount(activity, entry);
-      if (unit == null || amount == null || !Number.isFinite(amount)) {
-        throw new Error(`Invalid unit ${unit} or amount ${amount} for purchaseType ${purchaseType}. Expected ${entry.unit}`);
+      // First check if lineItems contains and calculate total of all line items
+      if (lineItems && lineItems.length) {
+        // TODO(df): What to do on a single line error? Abort all? Skip item?
+        footprint = lineItems.map(l => carbonEmissionOfLineItem(l)).reduce((a, b) => a + b, 0);
+      } else {
+        // Else take the purchaseType and other fields to calculate by passing a single line item
+        footprint = carbonEmissionOfLineItem({ name: purchaseType, unit: costCurrency || UNIT_ITEM, value: costAmount || 1 });
       }
-
-      if (entry.unit !== unit) {
-        throw new Error(`Invalid unit ${unit} given for purchaseType ${purchaseType}. Expected ${entry.unit}`);
-      }
-      footprint = entry.intensityKilograms * amount;
+      if (!footprint) throw new Error(`Could not calculate carbonIntensity of purchase activity with purchaseType: ${purchaseType} and lineItems: ${JSON.stringify(lineItems)}`)
       break;
     }
 

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -144,21 +144,21 @@ function extractComptabileUnitAndAmount(lineItem, entry) {
 export function carbonEmissionOfLineItem(lineItem) {
   // The generic identifier property holds the purchaseType value, so rename to make clear..
   const { identifier } = lineItem;
-  const entry = getEntryByKey(purchaseType);
+  const entry = getEntryByKey(identifier);
   if (!entry) {
     throw new Error(`Unknown purchaseType identifier: ${identifier}`);
   }
   if (!entry.intensityKilograms) {
-    throw new Error(`Missing carbon intensity for purchaseType: ${purchaseType}`);
+    throw new Error(`Missing carbon intensity for purchaseType: ${identifier}`);
   }
 
   const { unit, amount } = extractComptabileUnitAndAmount(lineItem, entry);
   if (unit == null || amount == null || !Number.isFinite(amount)) {
-    throw new Error(`Invalid unit ${unit} or amount ${amount} for purchaseType ${purchaseType}. Expected ${entry.unit}`);
+    throw new Error(`Invalid unit ${unit} or amount ${amount} for purchaseType ${identifier}. Expected ${entry.unit}`);
   }
 
   if (entry.unit !== unit) {
-    throw new Error(`Invalid unit ${unit} given for purchaseType ${purchaseType}. Expected ${entry.unit}`);
+    throw new Error(`Invalid unit ${unit} given for purchaseType ${identifier}. Expected ${entry.unit}`);
   }
   return entry.intensityKilograms * amount;
 }

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -83,7 +83,7 @@ export const modelVersion = `3_${getChecksumOfFootprints()}`; // This model reli
 export const modelCanRunVersion = 1;
 export function modelCanRun(activity) {
   const {
-    costAmount, costCurrency, activityType, transportationMode, purchaseType, lineItems,
+    costAmount, costCurrency, activityType, transportationMode, lineItems,
   } = activity;
   if (costAmount && costCurrency) {
     if (activityType === ACTIVITY_TYPE_MEAL) return true;
@@ -98,9 +98,6 @@ export function modelCanRun(activity) {
           return false;
       }
     }
-  }
-  if (activityType === ACTIVITY_TYPE_PURCHASE && purchaseType) {
-    return true;
   }
   if (activityType === ACTIVITY_TYPE_PURCHASE && lineItems && lineItems.length) {
     return true;
@@ -145,7 +142,7 @@ function extractComptabileUnitAndAmount(lineItem, entry) {
  * @param {*} lineItem - Object of the the type { identifier: <string>, unit: <string>, value: <string>, costAmount: <float>, costCurrency: <string> }
  */
 export function carbonEmissionOfLineItem(lineItem) {
-  // The generic name property holds the purchaseType value, so rename to make clear..
+  // The generic identifier property holds the purchaseType value, so rename to make clear..
   const { identifier: purchaseType } = lineItem;
   const entry = getEntryByKey(purchaseType);
   if (!entry) {

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -204,7 +204,6 @@ export function carbonEmissions(activity) {
         // TODO(df): What to do on a single line error? Abort all? Skip item?
         footprint = lineItems.map(l => carbonEmissionOfLineItem(l)).reduce((a, b) => a + b, 0);
       }
-      if (!footprint) throw new Error(`Could not calculate carbonIntensity of purchase activity with lineItems: ${JSON.stringify(lineItems)}`)
       break;
     }
 

--- a/integrations/purchase/nordic-api-gateway.js
+++ b/integrations/purchase/nordic-api-gateway.js
@@ -194,6 +194,10 @@ async function parseTransactions(transactions, accountDisplayName, bankDisplayNa
     const category = parseCategory(transactions[i].category, categories);
 
     if (category && transactions[i].amount.value < 0) {
+      const costAmount = -transactions[i].amount.value;
+      const costCurrency = transactions[i].amount.currency;
+      const { purchaseType } = category;
+      const lineItems = purchaseType ? [{ identifier: purchaseType, costAmount, costCurrency }] : undefined;
       res.push({
         id: `nag_${transactions[i].id}`,
         activityType: category.activityType,
@@ -203,9 +207,9 @@ async function parseTransactions(transactions, accountDisplayName, bankDisplayNa
         accountDisplayName,
         bankDisplayName,
         bankIdentifier,
-        purchaseType: category.purchaseType,
-        costAmount: -transactions[i].amount.value,
-        costCurrency: transactions[i].amount.currency,
+        lineItems,
+        costAmount,
+        costCurrency,
       });
     }
   }

--- a/integrations/transportation/tripit.js
+++ b/integrations/transportation/tripit.js
@@ -9,6 +9,7 @@ import {
   TRANSPORTATION_MODE_PLANE,
   TRANSPORTATION_MODE_TRAIN,
   PURCHASE_CATEGORY_ENTERTAINMENT_HOTEL,
+  UNIT_ITEM,
 } from '../../definitions';
 import { HTTPError } from '../utils/errors';
 
@@ -207,7 +208,7 @@ async function fetchLodging(modifiedSince, isPast = true, logger) {
       return {
         id: s.id,
         activityType: ACTIVITY_TYPE_PURCHASE,
-        purchaseType: PURCHASE_CATEGORY_ENTERTAINMENT_HOTEL,
+        lineItems: [{ identifier: PURCHASE_CATEGORY_ENTERTAINMENT_HOTEL, unit: UNIT_ITEM, value: 1 }],
         countryCodeISO2: s.Address ? s.Address.country : null,
         locationLon: convertNanToNull(locationLon),
         locationLat: convertNanToNull(locationLat),


### PR DESCRIPTION
Part of https://github.com/tmrowco/tmrow/issues/1693. Since a purchase activity should also support multiple line entries (i.e. multiple products in one purchase), the decision was taken to combine this with the existing `ingredients` array type and create a generic `lineItems`.


# TODO:

- [x] Refactor `ingredients` to `lineItems`
- [x] Refactor `purchaseType` to `lineItems`