### PR TITLE
Fixes issue with purchase-model when date is a string

### DIFF
--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -278,7 +278,6 @@ export function carbonEmissions(activity) {
 
     case ACTIVITY_TYPE_PURCHASE: {
       const { lineItems, countryCodeISO2, datetime } = activity;
-      // console.log(typeof datetime, datetime);
       // First check if lineItems contains and calculate total of all line items
       if (lineItems && lineItems.length) {
         // TODO(df): What to do on a single line error? Abort all? Skip item?

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -124,8 +124,8 @@ function conversionCPI(eurAmount, referenceYear, countryCodeISO2, datetime) {
   if (!eurAmount || !datetime) {
     return eurAmount;
   }
-
-  const currentDateIndicator = datetime.getFullYear();
+  // Ensure that date is actually a date (and not just a string)
+  const currentDateIndicator = new Date(datetime).getFullYear();
 
   let CPIcurrent;
   if (
@@ -278,7 +278,7 @@ export function carbonEmissions(activity) {
 
     case ACTIVITY_TYPE_PURCHASE: {
       const { lineItems, countryCodeISO2, datetime } = activity;
-
+      // console.log(typeof datetime, datetime);
       // First check if lineItems contains and calculate total of all line items
       if (lineItems && lineItems.length) {
         // TODO(df): What to do on a single line error? Abort all? Skip item?


### PR DESCRIPTION
Currently the calculation of emissions is failing (silently) when date is a string and not a date object. This PR fixes that by allowing both.

The error: `Error while computing footprint: datetime.getFullYear is not a function `

I also re-arranged the tests a bit to group all the CPI related tests.