### PR TITLE
Fix CPI non monetary

### DIFF
--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -163,15 +163,16 @@ function conversionCPI(eurAmount, referenceYear, countryCodeISO2, datetime) {
  * @param {*} countryCodeISO2 - country code of the activity
  * @param {*} datetime - datetime of the activity
  */
-function extractComptabileUnitAndAmount(lineItem, entry, countryCodeISO2, datetime) {
+function extractCompatibleUnitAndAmount(lineItem, entry, countryCodeISO2, datetime) {
   const isMonetaryItem = getAvailableCurrencies().includes(lineItem.unit);
   // Extract eurAmount if applicable
   let eurAmount = extractEur({
     costCurrency: isMonetaryItem ? lineItem.unit : null,
     costAmount: isMonetaryItem ? lineItem.value : null,
   });
-  // TODO(olc): Also look at potential available conversions
-  eurAmount = conversionCPI(eurAmount, entry.year, countryCodeISO2, datetime);
+  if (eurAmount) {
+    eurAmount = conversionCPI(eurAmount, entry.year, countryCodeISO2, datetime);
+  }
   const availableEntryUnit = entry.unit;
   if (availableEntryUnit === UNIT_LITER && lineItem.unit === UNIT_LITER) {
     return { unit: UNIT_LITER, amount: lineItem.value };
@@ -201,11 +202,8 @@ export function carbonEmissionOfLineItem(lineItem, countryCodeISO2, datetime) {
   if (!entry.intensityKilograms) {
     throw new Error(`Missing carbon intensity for purchaseType: ${identifier}`);
   }
-  if (!entry.year) {
-    throw new Error(`Missing consumer price index reference year for purchaseType: ${identifier}`);
-  }
 
-  const { unit, amount } = extractComptabileUnitAndAmount(
+  const { unit, amount } = extractCompatibleUnitAndAmount(
     lineItem,
     entry,
     countryCodeISO2,

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -125,6 +125,10 @@ function conversionCPI(eurAmount, referenceYear, countryCodeISO2, datetime) {
     return eurAmount;
   }
 
+  if (!referenceYear) {
+    throw new Error(`Missing consumer price index reference year`);
+  }
+
   const currentDateIndicator = datetime.getFullYear();
 
   let CPIcurrent;

--- a/co2eq/purchase/index.test.js
+++ b/co2eq/purchase/index.test.js
@@ -129,7 +129,7 @@ test(`test household appliance for DK in DKK`, () => {
   );
 });
 
-test(`test diesel 10L`, () => {
+test(`test non-monetary units`, () => {
   const activity = {
     activityType: ACTIVITY_TYPE_PURCHASE,
     datetime: new Date('2020-04-11T10:20:30Z'),

--- a/co2eq/purchase/index.test.js
+++ b/co2eq/purchase/index.test.js
@@ -128,3 +128,13 @@ test(`test household appliance for DK in DKK`, () => {
     (1150 / 7.4644) * (103.3 / 95.9) * 0.817390437852872
   );
 });
+
+test(`test diesel 10L`, () => {
+  const activity = {
+    activityType: ACTIVITY_TYPE_PURCHASE,
+    datetime: new Date('2020-04-11T10:20:30Z'),
+    lineItems: [{ identifier: 'Diesel', unit: 'L', value: 10 }],
+  };
+  expect(modelCanRun(activity)).toBeTruthy();
+  expect(carbonEmissions(activity)).toBeCloseTo(31.7);
+});


### PR DESCRIPTION
The purchase model was failing with error "Missing consumer price index reference year" when applied to a purchase that wasn't monetary (such as 10 L of diesel).
The bug was fixed and a unit test was added.
FYI @pierresegonne 