### PR TITLE
Add option for ferry to specify if a passenger is taking a car to the ferry or not

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ playground/dist
 .DS_Store
 coverage
 *.log
+package-lock.json

--- a/co2eq/ferry/ferries.json
+++ b/co2eq/ferry/ferries.json
@@ -1,0 +1,7 @@
+{
+  "footprints": [
+    {"withVehicle": null, "carbonIntensity": 0.11286},
+    {"withVehicle": true, "carbonIntensity": 0.12952},
+    {"withVehicle": false, "carbonIntensity": 0.01874}
+  ]
+}

--- a/co2eq/ferry/index.js
+++ b/co2eq/ferry/index.js
@@ -1,0 +1,57 @@
+import { ACTIVITY_TYPE_TRANSPORTATION, TRANSPORTATION_MODE_FERRY } from '../../definitions';
+import { getActivityDurationHours } from '../utils';
+import ferries from './ferries.json'; // source: https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019  -- tab: 'Business travel- sea'
+
+export const modelName = 'ferry';
+export const modelVersion = '1';
+export const explanation = {};
+
+export const modelCanRunVersion = 2; // not sure what number should come here
+export function modelCanRun(activity) {
+  const { activityType, transportationMode } = activity;
+  if (
+    activityType === ACTIVITY_TYPE_TRANSPORTATION &&
+    transportationMode === TRANSPORTATION_MODE_FERRY
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// look up carbon intensity for ferry depending on if it is a foot passenger or a passenger with a vehicle
+
+
+function carbonIntensity(hasVehicle) {
+  const entry = ferries.footprints.find(
+    // Using == instead of === because we want undefined to match with null in const ferries
+    d => d.withVehicle == hasVehicle
+  );
+  if (!entry) {
+    throw new Error(`Unknown input for hasVehicle ${hasVehicle}`);
+  }
+  return entry.carbonIntensity;
+}
+
+
+/*
+Carbon emissions of an activity (in kgCO2eq)
+*/
+export function carbonEmissions(activity) {
+  let { distanceKilometers } = activity;
+  if (!distanceKilometers) {
+    // fallback on duration if available
+    const durationHours = getActivityDurationHours(activity);
+    if ((durationHours || 0) > 0) {
+      // Acc. to Rome2rio, ferry from Menorca to Mallorca is 189.3km in 6h --> 31.55 km/h (https://www.rome2rio.com/map/Palma/Mahon-Airport-MAH) --> Rounding up to 30
+      distanceKilometers = durationHours * 30.0; //avg speed 30 km/h
+    } else {
+      throw new Error(
+        `Couldn't calculate carbonEmissions for activity because distanceKilometers = ${distanceKilometers} and datetime = ${activity.datetime} and endDatetime = ${activity.endDatetime}`
+      );
+    }
+  }
+
+  return (
+    (carbonIntensity(activity.withVehicle) * distanceKilometers)
+  );
+}

--- a/co2eq/ferry/index.test.js
+++ b/co2eq/ferry/index.test.js
@@ -1,0 +1,87 @@
+import moment from 'moment';
+import {
+  TRANSPORTATION_MODE_FERRY,
+  ACTIVITY_TYPE_TRANSPORTATION,
+} from '../../definitions';
+import ferries from './ferries.json';
+import { modelCanRun, carbonEmissions } from './index';
+
+describe('model runs with vehicle null', () => {
+  // const withVehicle = null;
+  const durationHours = 6;
+  const distance = 80;
+
+  const distanceActivity = {
+    activityType: ACTIVITY_TYPE_TRANSPORTATION,
+    distanceKilometers: distance,
+    transportationMode: TRANSPORTATION_MODE_FERRY,
+  };
+  const durationActivity = {
+    activityType: ACTIVITY_TYPE_TRANSPORTATION,
+    transportationMode: TRANSPORTATION_MODE_FERRY,
+    datetime: moment(),
+    endDatetime: moment().add(durationHours, 'hours'),
+  };
+
+  const failingActivity = {
+    ...distanceActivity,
+    activityType: 'unknown',
+  };
+
+  test(`modelCanRun`, () => {
+    expect(modelCanRun(distanceActivity)).toBeTruthy();
+    expect(modelCanRun(failingActivity)).toBeFalsy();
+  });
+
+  test('with distance', () => {
+    expect(carbonEmissions(distanceActivity)).toBeCloseTo(distance * 0.11286);
+  });
+
+  test('with duration', () => {
+    const durationToDistance = durationHours * 30;
+    expect(modelCanRun(durationActivity)).toBeTruthy();
+    expect(carbonEmissions(durationActivity)).toBeCloseTo(durationToDistance * 0.11286);
+  });
+  test('throw on zero duration', () => {
+    const zeroDurationActivity = {
+      ...durationActivity,
+      endDatetime: durationActivity.datetime,
+    };
+
+    expect(() => {
+      carbonEmissions(zeroDurationActivity);
+    }).toThrow();
+  });
+});
+
+
+describe('model runs with input for vehicle', () => {
+  const distance = 100;
+  const supportedInputs = [true, false, null];
+
+  const activity = {
+    activityType: ACTIVITY_TYPE_TRANSPORTATION,
+    distanceKilometers: distance,
+    transportationMode: TRANSPORTATION_MODE_FERRY,
+  };
+
+  test(`throw on unsupported value for withVehicle`, () => {
+    const unsupportedActivity = {
+      ...activity,
+      withVehicle: 'A',
+    };
+    expect(() => {
+      carbonEmissions(unsupportedActivity);
+    }).toThrow();
+  });
+
+
+  ferries.footprints.forEach(ferryOption => {
+    const testActivity = { ...activity, ...ferryOption };
+    test(`${ferries.withVehicle || 'unknown'} as withVehicle input`, () => {
+      expect(supportedInputs).toContain(ferryOption.withVehicle);
+      expect(modelCanRun(testActivity)).toBeTruthy();
+      expect(carbonEmissions(testActivity)).toBeCloseTo(distance * ferryOption.carbonIntensity);
+    });
+  });
+});

--- a/co2eq/index.js
+++ b/co2eq/index.js
@@ -4,6 +4,7 @@ import * as ingredientsCarbonModel from './food/ingredients';
 import * as transportationCarbonModel from './transportation/index';
 import * as flightCarbonModel from './flights/index';
 import * as carCarbonModel from './car/index';
+import * as ferryCarbonModel from './ferry/index';
 import * as purchaseCarbonModel from './purchase/index';
 import * as energyCarbonModel from './energy/index';
 import * as hotelCarbonModel from './hotelpercountry/index';
@@ -14,6 +15,7 @@ const carbonModels = [
   mealCarbonModel,
   carCarbonModel,
   flightCarbonModel,
+  ferryCarbonModel,
   transportationCarbonModel,
   energyCarbonModel,
   hotelCarbonModel,

--- a/co2eq/transportation/index.js
+++ b/co2eq/transportation/index.js
@@ -79,7 +79,8 @@ function carbonIntensity(mode) {
       );
     case TRANSPORTATION_MODE_FERRY:
       // See https://en.wikipedia.org/wiki/Carbon_footprint
-      return 120 / 1000.0;
+      // New source: https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019  -- tab: 'Business travel- sea'
+      return 112.86 / 1000.0;
     case TRANSPORTATION_MODE_BIKE:
       // https://ecf.com/files/wp-content/uploads/ECF_BROCHURE_EN_planche.pdf
       return 5 / 1000.0;


### PR DESCRIPTION
Created a new subfolder for `ferry`.

Source the data: https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019  -- tab: 'Business travel- sea'
