### PR TITLE
Adds index.js to purchase integration folder to fix north compatibility

### DIFF
--- a/integrations/purchase/index.js
+++ b/integrations/purchase/index.js
@@ -1,1 +1,1 @@
-export * from './nordic-api-gateway';
+export { default as nordicApiGateway } from './nordic-api-gateway';

--- a/integrations/purchase/index.js
+++ b/integrations/purchase/index.js
@@ -1,0 +1,1 @@
+export * from './nordic-api-gateway';


### PR DESCRIPTION
North imports all modules (or better: `*.js`) found in each the integrations folders in `contrib`. Since the `nag-categories.js` file is no source in itself, this breaks North. Added a quickfix but not sure if this may break Bloom?

Alternatively we just fix it in North, i.e. ignore the `Purchase` integrations (since they are not active anyway...)