### PR TITLE
Adds id to all integrations

### DIFF
--- a/integrations/digital/outlook.js
+++ b/integrations/digital/outlook.js
@@ -9,6 +9,7 @@ import { OAuth2Manager } from '../authentication';
 import { getActivitiesFromEmail } from './parsers/index';
 
 const config = {
+  id: 'outlook',
   label: 'Outlook',
   description: 'Detects purchases from your outlook email account from amazon.ca and ikea.ca.',
   isPrivate: true,

--- a/integrations/electricity/barry.js
+++ b/integrations/electricity/barry.js
@@ -201,6 +201,7 @@ async function collect(state, { logWarning }) {
 }
 
 const config = {
+  id: 'barry',
   description: 'collects electricity data from your smart meter',
   label: 'Barry',
   country: 'DK',

--- a/integrations/electricity/energinet.js
+++ b/integrations/electricity/energinet.js
@@ -167,10 +167,10 @@ async function disconnect() {
 }
 
 const config = {
-  description: 'collects electricity data from your smart meter',
+  id: 'energinet',
+  description: 'Collects electricity data from your smart meter',
   label: 'Energinet',
   country: 'DK',
-  isPrivate: true,
   type: ACTIVITY_TYPE_ELECTRICITY,
   signupLink:
     'https://www.notion.so/tmrow/How-to-get-a-token-for-Energinet-c4cdc0e568424177892056c284f45c23',

--- a/integrations/electricity/linky.js
+++ b/integrations/electricity/linky.js
@@ -185,6 +185,7 @@ async function collect(state, logger) {
 }
 
 const config = {
+  id: 'linky',
   label: 'Linky',
   country: 'FR',
   description: 'collects electricity data from your smart meter',

--- a/integrations/electricity/orsted.js
+++ b/integrations/electricity/orsted.js
@@ -130,6 +130,7 @@ async function collect(state, logger) {
 }
 
 const config = {
+  id: 'orsted',
   description: 'collects electricity data from your smart meter',
   label: 'Ørsted',
   country: 'DK',

--- a/integrations/electricity/renault-zoe.js
+++ b/integrations/electricity/renault-zoe.js
@@ -411,6 +411,7 @@ async function collect(state = {}, logger, utils) {
 }
 
 const config = {
+  id: 'renault-zoe',
   label: 'Renault Zoé',
   description: 'collects vehicle charging hours',
   type: ACTIVITY_TYPE_ELECTRIC_VEHICLE_CHARGING,

--- a/integrations/electricity/sense.js
+++ b/integrations/electricity/sense.js
@@ -96,6 +96,7 @@ async function collect(state, { logWarning }, { settings }) {
 }
 
 const config = {
+  id: 'sense',
   description: 'collects electricity usage from your Sense device',
   label: 'Sense',
   // Sense is currently in US and CA as of June 2019.

--- a/integrations/electricity/tesla-cockpit.js
+++ b/integrations/electricity/tesla-cockpit.js
@@ -138,6 +138,7 @@ async function collect(state, logger, utils) {
 }
 
 const config = {
+  id: 'tesla-cockpit',
   contributors: ['corradio'],
   label: 'Tesla Cockpit',
   signupLink: 'https://beta.teslacockpit.com/',

--- a/integrations/purchase/nordic-api-gateway.js
+++ b/integrations/purchase/nordic-api-gateway.js
@@ -241,6 +241,7 @@ async function collect(state, logger) {
 }
 
 const config = {
+  id: 'nordic-api-gateway',
   contributors: ['FelixDQ', 'Kongkille'],
   label: 'Nordic API Gateway',
   country: 'DK',

--- a/integrations/transportation/automatic.js
+++ b/integrations/transportation/automatic.js
@@ -110,6 +110,7 @@ async function collect(state, logger) {
 }
 
 const config = {
+  id: 'automatic',
   label: 'Automatic',
   description: 'collects data from your car rides',
   type: ACTIVITY_TYPE_TRANSPORTATION,

--- a/integrations/transportation/minvolkswagen.js
+++ b/integrations/transportation/minvolkswagen.js
@@ -160,6 +160,7 @@ async function collect(state, logger) {
 }
 
 const config = {
+  id: 'minvolkswagen',
   label: 'MinVolkswagen',
   description: 'collects data from your volkswagen car rides',
   type: ACTIVITY_TYPE_TRANSPORTATION,

--- a/integrations/transportation/rejsekort.js
+++ b/integrations/transportation/rejsekort.js
@@ -340,6 +340,7 @@ async function collect(state, logger) {
 }
 
 const config = {
+  id: 'rejsekort',
   label: 'Rejsekort',
   country: 'DK',
   type: ACTIVITY_TYPE_TRANSPORTATION,

--- a/integrations/transportation/ryanair.js
+++ b/integrations/transportation/ryanair.js
@@ -145,6 +145,7 @@ async function collect(state) {
 }
 
 const config = {
+  id: 'ryanair',
   label: 'Ryanair',
   description: 'collects your Ryanair plane rides',
   type: ACTIVITY_TYPE_TRANSPORTATION,

--- a/integrations/transportation/tfl.js
+++ b/integrations/transportation/tfl.js
@@ -253,6 +253,7 @@ async function disconnect() {
 }
 
 const config = {
+  id: 'tfl',
   label: 'Transport for London',
   country: 'UK',
   type: ACTIVITY_TYPE_TRANSPORTATION,

--- a/integrations/transportation/trainline.js
+++ b/integrations/transportation/trainline.js
@@ -139,6 +139,7 @@ async function collect(state, logger) {
 }
 
 const config = {
+  id: 'trainline',
   label: 'Trainline',
   type: ACTIVITY_TYPE_TRANSPORTATION,
   description: 'collects trips from your train and bus journeys',

--- a/integrations/transportation/tripit.js
+++ b/integrations/transportation/tripit.js
@@ -14,6 +14,7 @@ import {
 import { HTTPError } from '../utils/errors';
 
 const config = {
+  id: 'tripit',
   label: 'TripIt',
   description: 'collects plane, train and hotel activities from your emails',
   type: ACTIVITY_TYPE_TRANSPORTATION,

--- a/integrations/transportation/uber.js
+++ b/integrations/transportation/uber.js
@@ -92,6 +92,7 @@ async function collect(state, { logDebug }) {
 }
 
 const config = {
+  id: 'uber',
   contributors: ['willtonkin', 'corradio'],
   label: 'Uber',
   type: ACTIVITY_TYPE_TRANSPORTATION,

--- a/integrations/transportation/wizzair.js
+++ b/integrations/transportation/wizzair.js
@@ -179,6 +179,7 @@ async function collect(state) {
 }
 
 const config = {
+  id: 'wizzair',
   label: 'WizzAir',
   description: 'collects your Wizz Air plane rides',
   type: ACTIVITY_TYPE_TRANSPORTATION,


### PR DESCRIPTION
This PR adds an `id` field to the config object of all integrations. 

This will make it easier to have a unique, URL-friendly name for all integrations.