### PR TITLE
Fix co2eq cpi conversion.

### DIFF
--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -165,7 +165,7 @@ function conversionCPI(eurAmount, referenceYear, countryCodeISO2, datetime) {
   }
 
   // ref: https://www.investopedia.com/terms/c/consumerpriceindex.asp
-  const eurAmountAdjusted = eurAmount * (CPIcurrent / CPIreference);
+  const eurAmountAdjusted = eurAmount * (CPIreference / CPIcurrent);
   return eurAmountAdjusted;
 }
 

--- a/co2eq/purchase/index.test.js
+++ b/co2eq/purchase/index.test.js
@@ -54,7 +54,7 @@ test(`test household appliance for DK in EUR`, () => {
   };
   expect(modelCanRun(activity)).toBeTruthy();
   // original price * cpi correction * intensity
-  expect(carbonEmissions(activity)).toBeCloseTo(15 * (103.3 / 95.9) * 0.4028253119428596);
+  expect(carbonEmissions(activity)).toBeCloseTo(15 * (95.9 / 103.3) * 0.4028253119428596);
 });
 
 test(`test household appliance for DK in EUR, without any date specified`, () => {
@@ -113,7 +113,7 @@ test(`test household appliance for AU in EUR in 2020, for which there is no cpi 
   // original price * cpi correction * intensity
   // (average fallback used for 2020 as AU does not have data for 2020 yet)
   expect(carbonEmissions(activity)).toBeCloseTo(
-    15 * (110.72093023255815 / 92.2) * 0.4428823364363346
+    15 * (92.2 / 110.72093023255815) * 0.4428823364363346
   );
 });
 
@@ -132,7 +132,7 @@ test(`test household appliance for DK in DKK`, () => {
   };
   expect(modelCanRun(activity)).toBeTruthy();
   expect(carbonEmissions(activity)).toBeCloseTo(
-    (1150 / 7.4506) * (103.3 / 95.9) * 0.817390437852872
+    (1150 / 7.4506) * (95.9 / 103.3) * 0.817390437852872
   );
 });
 


### PR DESCRIPTION
Looking at the CO2e transparency flow, I realised the massive mistake I did in the past when implementing the CPI conversion.

The conversion used to be done with 

```
const eurAmountAdjusted = eurAmount * (CPIcurrent / CPIreference);
```

where `CPIcurrent` refers to the CPI for the year of the datetime of the activity and `CPIreference` to the CPI for the year of the reference year (2011 for EXIOBASE data). It should be instead:

```
const eurAmountAdjusted = eurAmount * (CPIreference / CPIcurrent);
```


To show why, imagine 10€ in 2020€ spent in DE. The CPI for 2011 is 95.2, the CPI for 2020 is 105.5. With the old model, the adjusted price would thus be 10 * (105.5 / 95.2) = 11.08€. With the new model it becomes 10 * (95.2 / 105.5) = 9.02€.
To check, think about old prices re-adjusted for current money, the old prices are always lower than current prices (at least for most countries on the long scale, see for example https://www.bankofengland.co.uk/monetary-policy/inflation/inflation-calculator )


A sanity check on the homgeneity of the formula shows it too:

X_{€,2011} = X_{€,2020} * (CPI_{2011} / CPI_{2020})